### PR TITLE
remove truncate in favor of more advanced trimLabel fn

### DIFF
--- a/src/common/utils/truncate.ts
+++ b/src/common/utils/truncate.ts
@@ -1,7 +1,0 @@
-export function truncate(text, length) {
-  if (text.toString().length > length) {
-    return text.toString().substring(0, length) + "...";
-  } else {
-    return text;
-  }
-}

--- a/src/piechart/AdvancedPieChart.ts
+++ b/src/piechart/AdvancedPieChart.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
 import { calculateViewDimensions, ViewDimensions } from '../common/viewDimensions';
 import { colorHelper } from '../utils/colorSets';
 import { BaseChart } from '../common/BaseChart';
-import { truncate } from '../common/utils/truncate';
+import { trimLabel } from '../common/trimLabel';
 
 export interface LegendItem {
   value: number;
@@ -129,7 +129,7 @@ export class AdvancedPieChart extends BaseChart implements OnInit {
       let percentage = Math.round(value / this.total * 100);
       return {
         value: Math.round(value),
-        label: truncate(label, 20),
+        label: trimLabel(label, 20),
         percentage: percentage
       };
     });


### PR DESCRIPTION
There's already a `trimLabel` helper function in the `common` folder which seems more advanced than the `truncate` function. This PR replaces `truncate` with the `trimLabel` function.

There's one thing left, @ocombe, [you use a value of `20`](https://github.com/swimlane/a2d3/blob/master/src/piechart/AdvancedPieChart.ts#L132) in your truncate function...

``` javascript
...
return {
   value: Math.round(value),
   label: truncate(label, 20),
   percentage: percentage
};
```

...while @amcdnl seems to use a value of `16` by default in "his" `trimLabel` function. I think we should agree on the same default. 😊 

@ocombe Feel free to merge this in if you consider this ok. //cc @amcdnl 
