### PR TITLE
Use CommonModule instead of BrowserModule in lib

### DIFF
--- a/src/common/axes/axes.module.ts
+++ b/src/common/axes/axes.module.ts
@@ -4,10 +4,10 @@ import {XAxis} from "./x-axis.component";
 import {XAxisTicks} from "./x-axis-ticks.component";
 import {YAxis} from "./y-axis.component";
 import {YAxisTicks} from "./y-axis-ticks.component";
-import {BrowserModule} from "@angular/platform-browser";
+import {CommonModule} from "@angular/common";
 
 @NgModule({
-  imports: [BrowserModule],
+  imports: [CommonModule],
   declarations: [AxisLabel, XAxis, XAxisTicks, YAxis, YAxisTicks],
   exports: [AxisLabel, XAxis, XAxisTicks, YAxis, YAxisTicks]
 })

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -11,7 +11,7 @@ import { GridPanelSeries } from "./grid-panel-series.component";
 import { SvgLinearGradient } from "./svg-linear-gradient.component";
 import { SvgRadialGradient } from "./svg-radial-gradient.component";
 import { Timeline } from "./timeline.component";
-import { BrowserModule } from "@angular/platform-browser";
+import { CommonModule as Ng2CommonModule } from "@angular/common";
 import { Area } from "./area.component";
 import { AreaTooltip } from "./area-tooltip.component";
 
@@ -32,7 +32,7 @@ const COMPONENTS = [
 
 @NgModule({
   imports: [
-    BrowserModule,
+    Ng2CommonModule,
     AxesModule,
     TooltipModule
   ],
@@ -40,7 +40,7 @@ const COMPONENTS = [
     ...COMPONENTS
   ],
   exports: [
-    BrowserModule,
+    Ng2CommonModule,
     AxesModule,
     TooltipModule,
     ...COMPONENTS

--- a/src/common/tooltip/tooltip.module.ts
+++ b/src/common/tooltip/tooltip.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { CommonModule } from '@angular/common';
 
 import { TooltipDirective } from './tooltip.directive';
 import { TooltipContentComponent } from './tooltip.component';
@@ -11,7 +11,7 @@ import { InjectionService } from '../../utils/injection.service';
   declarations: [TooltipContentComponent, TooltipDirective],
   providers: [InjectionService, TooltipService],
   exports: [TooltipContentComponent, TooltipDirective],
-  imports: [BrowserModule],
+  imports: [CommonModule],
   entryComponents: [TooltipContentComponent]
 })
 export class TooltipModule { }


### PR DESCRIPTION
Apps that are using lazy loading will get errors if the lazy loaded module imports the BrowserModule (or imports NG2D3Module that imports BrowserModule).  I swapped out BrowserModule for CommonModule in all the ng2d3 imports.  The demo still imports BrowserModule, since that's the right place for it.

All the tests still pass, and the demo still works.  I'll look at AoT next.