### PR TITLE
Force Directed Graph

### DIFF
--- a/demo/app.ts
+++ b/demo/app.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit} from '@angular/core';
-import {single, multi, countries, generateData} from './data';
+import {single, multi, countries, generateData, generateGraph} from './data';
 import chartGroups from './chartTypes';
 import '../src/ng2d3.scss';
 import './demo.scss';
@@ -182,6 +182,17 @@ import './demo.scss';
             [showGridLines]="showGridLines"
             (clickHandler)="clickHandler($event)">
           </line-chart>
+
+          <force-directed-graph
+            *ngIf="chartType === 'force-directed-graph'"
+            [legend]="showLegend"
+            [links]="graph.links"
+            [nodes]="graph.nodes"
+            [scheme]="colorScheme"
+            [view]="view"
+            (clickHandler)="clickHandler($event)">
+          </force-directed-graph>
+
           <area-chart
             *ngIf="chartType === 'area-chart'"
             [view]="view"
@@ -405,6 +416,7 @@ export class App implements OnInit {
   single: any[];
   multi: any[];
   dateData: any[];
+  graph: { links: any[], nodes: any[] };
   linearScale: boolean = false;
 
   view: any[];
@@ -437,7 +449,7 @@ export class App implements OnInit {
   timeline = false;
 
   constructor() {
-    Object.assign(this, {single, multi, countries, chartGroups});
+    Object.assign(this, {single, multi, countries, chartGroups, graph: generateGraph(5) });
 
     this.dateData = generateData(5);
   }
@@ -469,6 +481,19 @@ export class App implements OnInit {
         this.multi.splice(index, 1);
         this.multi = [...this.multi];
       }
+
+      if (this.graph.nodes.length > 1) {
+        let index = Math.floor(Math.random() * this.graph.nodes.length);
+        let value = this.graph.nodes[index].value;
+        this.graph.nodes.splice(index, 1);
+        const nodes = [ ...this.graph.nodes ];
+
+        const links = this.graph.links.filter(link => {
+          return link.source !== value && link.source.value !== value &&
+            link.target !== value && link.target.value !== value;
+        });
+        this.graph = { links, nodes };
+      }
     }
 
     if (add) {
@@ -492,6 +517,16 @@ export class App implements OnInit {
       };
 
       this.multi = [...this.multi, multiEntry];
+
+      // graph
+      const node = { value: country };
+      const nodes = [ ...this.graph.nodes, node];
+      const link = {
+        source: country,
+        target: nodes[Math.floor(Math.random() * (nodes.length - 1))].value,
+      };
+      const links = [ ...this.graph.links, link];
+      this.graph = { links, nodes };
     }
   }
 

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -108,6 +108,12 @@ let chartGroups = [
     name: "Other Charts",
     charts: [
       {
+        name: "Force Directed Graph",
+        selector: 'force-directed-graph',
+        inputFormat: 'graph',
+        options: ['colorScheme', 'showLegend']
+      },
+      {
         name: "Heat Map",
         selector: 'heat-map',
         inputFormat: 'multiSeries',

--- a/demo/data.ts
+++ b/demo/data.ts
@@ -61,6 +61,25 @@ export var countries = [
   "Abkhazia", "Afghanistan", "Akrotiri and Dhekelia", "Aland", "Albania", "Algeria", "American Samoa", "Andorra", "Angola", "Anguilla", "Antigua and Barbuda", "Argentina", "Armenia", "Aruba", "Ascension Island", "Australia", "Austria", "Azerbaijan", "Bahamas, The", "Bahrain", "Bangladesh", "Barbados", "Belarus", "Belgium", "Belize", "Benin", "Bermuda", "Bhutan", "Bolivia", "Bosnia and Herzegovina", "Botswana", "Brazil", "Brunei", "Bulgaria", "Burkina Faso", "Burundi", "Cambodia", "Cameroon", "Canada", "Cape Verde", "Cayman Islands", "Central Africa Republic", "Chad", "Chile", "China", "Christmas Island", "Cocos (Keeling) Islands", "Colombia", "Comoros", "Congo", "Cook Islands", "Costa Rica", "Cote d'lvoire", "Croatia", "Cuba", "Cyprus", "Czech Republic", "Denmark", "Djibouti", "Dominica", "Dominican Republic", "East Timor Ecuador", "Egypt", "El Salvador", "Equatorial Guinea", "Eritrea", "Estonia", "Ethiopia", "Falkland Islands", "Faroe Islands", "Fiji", "Finland", "France", "French Polynesia", "Gabon", "Cambia, The", "Georgia", "Germany", "Ghana", "Gibraltar", "Greece", "Greenland", "Grenada", "Guam", "Guatemala", "Guemsey", "Guinea", "Guinea-Bissau", "Guyana", "Haiti", "Honduras", "Hong Kong", "Hungary", "Iceland", "India", "Indonesia", "Iran", "Iraq", "Ireland", "Isle of Man", "Israel", "Italy", "Jamaica", "Japan", "Jersey", "Jordan", "Kazakhstan", "Kenya", "Kiribati", "Korea, N", "Korea, S", "Kosovo", "Kuwait", "Kyrgyzstan", "Laos", "Latvia", "Lebanon", "Lesotho", "Liberia", "Libya", "Liechtenstein", "Lithuania", "Luxembourg", "Macao", "Macedonia", "Madagascar", "Malawi", "Malaysia", "Maldives", "Mali", "Malta", "Marshall Islands", "Mauritania", "Mauritius", "Mayotte", "Mexico", "Micronesia", "Moldova", "Monaco", "Mongolia", "Montenegro", "Montserrat", "Morocco", "Mozambique", "Myanmar", "Nagorno-Karabakh", "Namibia", "Nauru", "Nepal", "Netherlands", "Netherlands Antilles", "New Caledonia", "New Zealand", "Nicaragua", "Niger", "Nigeria", "Niue", "Norfolk Island", "Northern Cyprus", "Northern Mariana Islands", "Norway", "Oman", "Pakistan", "Palau", "Palestine", "Panama", "Papua New Guinea", "Paraguay", "Peru", "Philippines", "Pitcaim Islands", "Poland", "Portugal", "Puerto Rico", "Qatar", "Romania", "Russia", "Rwanda", "Sahrawi Arab Democratic Republic", "Saint-Barthelemy", "Saint Helena", "Saint Kitts and Nevis", "Saint Lucia", "Saint Martin", "Saint Pierre and Miquelon", "Saint Vincent and Grenadines", "Samos", "San Marino", "Sao Tome and Principe", "Saudi Arabia", "Senegal", "Serbia", "Seychelles", "Sierra Leone", "Singapore", "Slovakia", "Slovenia", "Solomon Islands", "Somalia", "Somaliland", "South Africa", "South Ossetia", "Spain", "Sri Lanka", "Sudan", "Suriname", "Svalbard", "Swaziland", "Sweden", "Switzerland", "Syria", "Tajikistan", "Tanzania", "Thailand", "Togo", "Tokelau", "Tonga", "Transnistria", "Trinidad and Tobago", "Tristan da Cunha", "Tunisia", "Turkey", "Turkmenistan", "Turks and Caicos Islands", "Tuvalu", "Uganda", "Ukraine", "United Arab Emirates", "United Kingdom", "United States", "Uruguay", "Uzbekistan", "Vanuatu", "Vatican City", "Venezuela", "Vietnam", "Virgin Islands, British", "Virgin Islands, U.S.", "Wallis and Futuna", "Yemen", "Zambia", "Zimbabwe"
 ];
 
+export function generateGraph(nodeCount: number) {
+  let nodes = [], links = [];
+  for (let i = 0; i < nodeCount; i++) {
+    let country = countries[Math.floor(Math.random() * countries.length)];
+    nodes.push({
+      value: country,
+    });
+    for (let j = 0; j < nodes.length - 1; j++) {
+      if (Math.random() < 0.5) {
+        links.push({
+          source: country,
+          target: nodes[j].value,
+        });
+      }
+    }
+  }
+  return { links, nodes };
+}
+
 export function generateData(seriesLength) {
   let results = [];
 

--- a/src/d3.ts
+++ b/src/d3.ts
@@ -3,6 +3,7 @@
 let array = require("d3-array");
 let brush = require("d3-brush");
 let color = require("d3-color");
+let force = require("d3-force");
 let format = require("d3-format");
 let interpolate = require("d3-interpolate");
 let scales = require("d3-scale");
@@ -18,6 +19,12 @@ export default {
   brushY: brush.brushY,
   event: selection.event,
   extent: array.extent,
+  forceCollide: force.forceCollide,
+  forceLink: force.forceLink,
+  forceManyBody: force.forceManyBody,
+  forceSimulation: force.forceSimulation,
+  forceX: force.forceX,
+  forceY: force.forceY,
   format: format.format,
   interpolate: interpolate.interpolate,
   line: shape.line,

--- a/src/force-directed-graph/force-directed-graph.component.ts
+++ b/src/force-directed-graph/force-directed-graph.component.ts
@@ -28,7 +28,7 @@ import {
 
       <svg:g [attr.transform]="transform" class="force-directed-graph chart">
         <svg:g class="links">
-          <svg:g *ngFor="let link of links">
+          <svg:g *ngFor="let link of links; trackBy:trackLinkBy">
             <template *ngIf="linkTemplate"
               [ngTemplateOutlet]="linkTemplate"
               [ngOutletContext]="{ $implicit: link }">
@@ -43,7 +43,7 @@ import {
           </svg:g>
         </svg:g>
         <svg:g class="nodes">
-          <svg:g *ngFor="let node of nodes"
+          <svg:g *ngFor="let node of nodes; trackBy:trackNodeBy"
             [attr.transform]="'translate(' + node.x + ',' + node.y + ')'"
             [attr.fill]="colors(groupResultsBy(node))"
             [attr.stroke]="colors(groupResultsBy(node))"
@@ -130,8 +130,12 @@ export class ForceDirectedGraph extends BaseChart implements OnChanges {
       .sort();
   }
 
-  trackBy(index, item) {
-    return item.name;
+  trackLinkBy(index, link) {
+    return link.index;
+  }
+
+  trackNodeBy(index, node) {
+    return node.value;
   }
 
   setColors() {

--- a/src/force-directed-graph/force-directed-graph.component.ts
+++ b/src/force-directed-graph/force-directed-graph.component.ts
@@ -1,0 +1,169 @@
+import { Chart } from '../common/charts/chart.component';
+import { BaseChart } from '../common/base-chart.component';
+import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
+import d3 from '../d3';
+import { colorHelper } from '../utils/color-sets';
+import {
+  Component,
+  ContentChild,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  NgZone,
+  OnChanges,
+  Output,
+  TemplateRef,
+  ViewChild
+} from '@angular/core';
+
+@Component({
+  selector: 'force-directed-graph',
+  template: `
+    <chart
+      [legend]="legend"
+      [view]="[width, height]"
+      [colors]="colors"
+      [legendData]="seriesDomain">
+
+      <svg:g [attr.transform]="transform" class="force-directed-graph chart">
+        <svg:g class="links">
+          <svg:g *ngFor="let link of links">
+            <template *ngIf="linkTemplate"
+              [ngTemplateOutlet]="linkTemplate"
+              [ngOutletContext]="{ $implicit: link }">
+            </template>
+            <svg:line *ngIf="!linkTemplate"
+              strokeWidth="1" stroke="black"
+              [attr.x1]="link.source.x"
+              [attr.y1]="link.source.y"
+              [attr.x2]="link.target.x"
+              [attr.y2]="link.target.y"
+            />
+          </svg:g>
+        </svg:g>
+        <svg:g class="nodes">
+          <svg:g *ngFor="let node of nodes"
+            [attr.transform]="'translate(' + node.x + ',' + node.y + ')'"
+            [attr.fill]="colors(groupResultsBy(node))"
+            [attr.stroke]="colors(groupResultsBy(node))"
+            (mousedown)="onDragStart(node, $event)"
+            (click)="click($event, node)"
+
+            swui-tooltip
+            [tooltipPlacement]="'top'"
+            [tooltipType]="'tooltip'"
+            [tooltipTitle]="node.value">
+            <template *ngIf="nodeTemplate"
+              [ngTemplateOutlet]="nodeTemplate"
+              [ngOutletContext]="{ $implicit: node }">
+            </template>
+            <svg:circle *ngIf="!nodeTemplate" r="5" />
+          </svg:g>
+        </svg:g>
+      </svg:g>
+    </chart>
+  `
+})
+export class ForceDirectedGraph extends BaseChart implements OnChanges {
+  colors: Function;
+  dims: ViewDimensions;
+  draggingNode: any;
+  draggingStart: { x: number, y: number };
+  margin = [0, 0, 0, 0];
+  results = [];
+  seriesDomain: any;
+  transform: string;
+
+  @Input() customColors;
+  @Input() force = d3.forceSimulation()
+    .force("charge", d3.forceManyBody())
+    .force("collide", d3.forceCollide(5))
+    .force("x", d3.forceX())
+    .force("y", d3.forceY());
+  @Input() forceLink = d3.forceLink().distance(20).strength(1).id(node => node.value);
+  @Input() groupResultsBy: (node: any) => string = node => node.value;
+  @Input() legend: boolean;
+  @Input() nodes: any[] = [];
+  @Input() links: { source: any, target: any }[] = [];
+  @Input() scheme;
+  @Input() view;
+
+  @Output() clickHandler = new EventEmitter();
+
+  @ContentChild('linkTemplate') linkTemplate: TemplateRef<any>;
+  @ContentChild('nodeTemplate') nodeTemplate: TemplateRef<any>;
+  @ViewChild(Chart, { read: ElementRef }) chart: ElementRef;
+
+  constructor(private element: ElementRef, zone: NgZone) {
+    super(element, zone);
+  }
+
+  ngOnChanges() {
+    this.update();
+  }
+
+  update() {
+    super.update();
+
+    // center graph
+    this.dims = calculateViewDimensions(this.width, this.height, this.margin, false, false, this.legend, 9);
+
+    this.seriesDomain = this.getSeriesDomain();
+    this.setColors();
+
+    this.transform = `translate(${ this.dims.xOffset + this.dims.width / 2 }, ${ this.margin[0] + this.dims.height / 2 })`;
+    if(this.force) {
+      this.force.nodes(this.nodes)
+        .force("link", this.forceLink.links(this.links))
+        .alpha(0.5).restart();
+    }
+  }
+
+  click($event, node) {
+    this.clickHandler.emit(node);
+  }
+
+  getSeriesDomain() {
+    return this.nodes.map(d => this.groupResultsBy(d))
+      .reduce((nodes: any[], node): any[] => nodes.includes(node) ? nodes : nodes.concat([node]), [])
+      .sort();
+  }
+
+  trackBy(index, item) {
+    return item.name;
+  }
+
+  setColors() {
+    this.colors = colorHelper(this.scheme, 'ordinal', this.seriesDomain, this.customColors);
+  }
+
+  // Easier to use Angular2 event management than use d3.drag
+  onDragStart(node, $event: MouseEvent) {
+    this.force.alphaTarget(0.3).restart();
+    this.draggingNode = node;
+    this.draggingStart = { x: $event.x - node.x, y: $event.y - node.y };
+    this.draggingNode.fx = $event.x - this.draggingStart.x;
+    this.draggingNode.fy = $event.y - this.draggingStart.y;
+  }
+
+  @HostListener('document:mousemove', ['$event'])
+  onDrag($event: MouseEvent) {
+    if (!this.draggingNode) {
+      return;
+    }
+    this.draggingNode.fx = $event.x - this.draggingStart.x;
+    this.draggingNode.fy = $event.y - this.draggingStart.y;
+  }
+
+  @HostListener('document:mouseup')
+  onDragEnd(node, $event: MouseEvent) {
+    if (!this.draggingNode) {
+      return;
+    }
+    this.force.alphaTarget(0);
+    this.draggingNode.fx = undefined;
+    this.draggingNode.fy = undefined;
+    this.draggingNode = undefined;
+  }
+}

--- a/src/force-directed-graph/force-directed-graph.module.ts
+++ b/src/force-directed-graph/force-directed-graph.module.ts
@@ -1,0 +1,16 @@
+import {NgModule} from "@angular/core";
+import {ForceDirectedGraph} from "./force-directed-graph.component";
+import {CommonModule} from "../common/common.module";
+
+export {ForceDirectedGraph}
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [
+    ForceDirectedGraph,
+  ],
+  exports: [
+    ForceDirectedGraph,
+  ]
+})
+export class ForceDirectedGraphModule {}

--- a/src/ng2d3.ts
+++ b/src/ng2d3.ts
@@ -2,6 +2,7 @@ import { NgModule } from "@angular/core";
 import { CommonModule } from "./common/common.module";
 import { AreaChartModule } from "./area-chart/area-chart.module";
 import { BarChartModule } from "./bar-chart/bar-chart.module";
+import { ForceDirectedGraphModule } from "./force-directed-graph/force-directed-graph.module";
 import { HeatMapModule } from "./heat-map/heat-map.module";
 import { LineChartModule } from "./line-chart/line-chart.module";
 import { NumberCardModule } from "./number-card/number-card.module";
@@ -10,6 +11,7 @@ import { TreeMapModule } from "./tree-map/tree-map.module";
 
 export * from "./area-chart/area-chart.module";
 export * from "./bar-chart/bar-chart.module";
+export * from "./force-directed-graph/force-directed-graph.module";
 export * from "./common/common.module";
 export * from "./heat-map/heat-map.module";
 export * from "./line-chart/line-chart.module";
@@ -22,6 +24,7 @@ export * from "./tree-map/tree-map.module";
     CommonModule,
     AreaChartModule,
     BarChartModule,
+    ForceDirectedGraphModule,
     HeatMapModule,
     LineChartModule,
     NumberCardModule,


### PR DESCRIPTION
Added force-directed-graph

This extends `BaseChart` for the dimension calculations, but doesn't use the `results` property since it doesn't use a series type data structure.

### The standard Chart inputs are present:
`customColors`, `legend`, `scheme`, and `view`.

### Inputs unique to ForceDirectedGraph include:

- `nodes: any[]` - Nodes in the graph
- `links: { source: any, target: any }[]` - Connects nodes together.  Source and target can be either an object reference or a node id.  See [forceLink().id](https://github.com/d3/d3-force#link_id)
- `force` - *(optional)* Customized d3.forceSimulation. Default:

        d3.forceSimulation()
          .force("charge", d3.forceManyBody())
          .force("collide", d3.forceCollide(5))
          .force("x", d3.forceX())
          .force("y", d3.forceY());

- `forceLink` - *(optional)* Customized d3.forceLink. Default:  

        d3.forceLink().distance(20).strength(1).id(node => node.value);

- `groupResultsBy` - *(optional)* Customized d3.forceLink. Default:  

        node => node.value


### Content templates can be used to create custom UI for nodes and links:

- `nodeTemplate` - *(optional)* Customized node template. Default is equivalent to:  

        <force-directed-graph ...>
          <template #nodeTemplate let-node>
            <svg:circle r="5" />
          </template>
        </force-directed-graph>

- `linkTemplate` - *(optional)* Customized link template. Default is equivalent to:  

        <force-directed-graph ...>
          <template #linkTemplate let-link>
            <svg:line strokeWidth="1" stroke="black"
              [attr.x1]="link.source.x"
              [attr.y1]="link.source.y"
              [attr.x2]="link.target.x"
              [attr.y2]="link.target.y"
            />
          </template>
        </force-directed-graph>
