### PR TITLE
Exposed tick width from the x and y ticks components

### DIFF
--- a/src/area-chart/area-chart.component.ts
+++ b/src/area-chart/area-chart.component.ts
@@ -46,6 +46,8 @@ import { id } from '../utils/id';
           [showLabel]="showXAxisLabel"
           [labelText]="xAxisLabel"
           [tickFormatting]="xAxisTickFormatting"
+          [maxTickWidth]="maxTickWidth"
+          [maxScaleTickWidth]="maxScaleTickWidth"
           (dimensionsChanged)="updateXAxisHeight($event)">
         </svg:g>
         <svg:g ngx-charts-y-axis
@@ -161,6 +163,10 @@ export class AreaChartComponent extends BaseChartComponent {
   @Input() xScaleMax: any;
   @Input() yScaleMin: number;
   @Input() yScaleMax: number;
+  @Input() maxTickWidth: number;
+  @Input() maxScaleTickWidth: number;
+  @Input() maxTickHeight: number;
+  @Input() maxScaleTickHeight: number;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/src/common/axes/x-axis-ticks.component.ts
+++ b/src/common/axes/x-axis-ticks.component.ts
@@ -53,6 +53,8 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
   @Input() showGridLines = false;
   @Input() gridLineHeight;
   @Input() width;
+  @Input() maxTickWidth;
+  @Input() maxScaleTickWidth;
 
   @Output() dimensionsChanged = new EventEmitter();
 
@@ -157,8 +159,8 @@ export class XAxisTicksComponent implements OnChanges, AfterViewInit {
 
   getTicks() {
     let ticks;
-    const maxTicks = this.getMaxTicks(20);
-    const maxScaleTicks = this.getMaxTicks(100);
+    const maxTicks = this.getMaxTicks(this.maxTickWidth || 20);
+    const maxScaleTicks = this.getMaxTicks(this.maxScaleTickWidth || 100);
 
     if (this.tickValues) {
       ticks = this.tickValues;

--- a/src/common/axes/x-axis.component.ts
+++ b/src/common/axes/x-axis.component.ts
@@ -27,6 +27,8 @@ import { XAxisTicksComponent } from './x-axis-ticks.component';
         [showGridLines]="showGridLines"
         [gridLineHeight]="dims.height"
         [width]="dims.width"
+        [maxTickWidth]="maxTickWidth"
+        [maxScaleTickWidth]="maxScaleTickWidth"
         (dimensionsChanged)="emitTicksHeight($event)"
       />
       <svg:g ngx-charts-axis-label
@@ -52,6 +54,8 @@ export class XAxisComponent implements OnChanges {
   @Input() xAxisTickInterval;
   @Input() xAxisTickCount: any;
   @Input() xOrient: string = 'bottom';
+  @Input() maxTickWidth: number;
+  @Input() maxScaleTickWidth: number;
 
   @Output() dimensionsChanged = new EventEmitter();
 

--- a/src/common/axes/y-axis-ticks.component.ts
+++ b/src/common/axes/y-axis-ticks.component.ts
@@ -90,6 +90,8 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
   @Input() referenceLines;
   @Input() showRefLabels: boolean = false;
   @Input() showRefLines: boolean = false;
+  @Input() maxTickHeight;
+  @Input() maxScaleTickHeight;
 
   @Output() dimensionsChanged = new EventEmitter();
 
@@ -221,8 +223,8 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
 
   getTicks(): any {
     let ticks;
-    const maxTicks = this.getMaxTicks(20);
-    const maxScaleTicks = this.getMaxTicks(50);
+    const maxTicks = this.getMaxTicks(this.maxTickHeight || 20);
+    const maxScaleTicks = this.getMaxTicks(this.maxScaleTickHeight || 50);
 
     if (this.tickValues) {
       ticks = this.tickValues;

--- a/src/common/axes/y-axis.component.ts
+++ b/src/common/axes/y-axis.component.ts
@@ -29,6 +29,8 @@ import { YAxisTicksComponent } from './y-axis-ticks.component';
         [showRefLines]="showRefLines"
         [showRefLabels]="showRefLabels"
         [height]="dims.height"
+        [maxTickHeight]="maxTickHeight"
+        [maxScaleTickHeight]="maxScaleTickHeight"
         (dimensionsChanged)="emitTicksWidth($event)"
       />
 
@@ -58,6 +60,8 @@ export class YAxisComponent implements OnChanges {
   @Input() referenceLines;
   @Input() showRefLines;
   @Input() showRefLabels;
+  @Input() maxTickHeight;
+  @Input() maxScaleTickHeight;
   @Output() dimensionsChanged = new EventEmitter();
 
   yAxisClassName: string = 'y axis';


### PR DESCRIPTION
Note: I'm resubmitting my pull request because I found a bug in my original PR (https://github.com/swimlane/ngx-charts/pull/769).

The following properties were created to allow developers to show more ticks on the x and y axis

- maxTickWidth/maxScaleTickWidth (x-axis-ticks.component.ts)
- maxTickHeight/maxScaleTickHeight (y-axis-ticks.component.ts)

These properties have only been made available for area-chart.component.ts, but can be applied to other charts. By default, if the value isn't specified, the tick width used will be the original values.

**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When the screen size isn't that wide and there are too many points to plot with different values, the max number of ticks that is displayed on the x-axis and y-axis is reduced. This is because the distance between ticks use hardcoded values and in my case, the maxScaleTicks was used and only 3 ticks showed on my x-axis instead of the 13 ticks that I was expecting.


**What is the new behavior?**
axis.component and y-axis.component.ts:

x-axis-ticks.component.ts
[maxTickWidth]
[maxScaleTickWidth]

y-axis-ticks.component.ts
[maxTickHeight]
[maxScaleTickHeight]



**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
In my case, I'm only using the area-chart.component.ts, so I only exposed my properties to this chart. However, any chart that uses the tick components could use this property as well.