### PR TITLE
added feature to set min and max in heatmaps

### DIFF
--- a/demo/app.component.html
+++ b/demo/app.component.html
@@ -468,6 +468,8 @@
         [scheme]="colorScheme"
         [results]="multi"
         [animations]="animations"
+        [min]="heatmapMin"
+        [max]="heatmapMax"
         [legend]="showLegend"
         [gradient]="gradient"
         (legendLabelClick)="onLegendLabelClick($event)"
@@ -1041,13 +1043,21 @@
           </option>
         </select>
       </div>
-      <div *ngIf="chart.options.includes('min')">
+      <div *ngIf="chart.options.includes('min') && chart.selector!='heat-map'">
         <label>Min value:</label><br />
         <input type="number" [(ngModel)]="gaugeMin"><br />
       </div>
-      <div *ngIf="chart.options.includes('max')">
+      <div *ngIf="chart.options.includes('max')  && chart.selector!='heat-map'">
         <label>Max value:</label><br />
         <input type="number" [(ngModel)]="gaugeMax"><br />
+      </div>
+      <div *ngIf="chart.options.includes('min')  && chart.selector=='heat-map'">
+        <label>Min value:</label><br />
+        <input type="number" [(ngModel)]="heatmapMin"><br />
+      </div>
+      <div *ngIf="chart.options.includes('max') && chart.selector=='heat-map'">
+        <label>Max value:</label><br />
+        <input type="number" [(ngModel)]="heatmapMax"><br />
       </div>
       <div *ngIf="chart.options.includes('innerPadding')">
         <label>Inner padding value:</label><br />

--- a/demo/app.component.ts
+++ b/demo/app.component.ts
@@ -163,6 +163,10 @@ export class AppComponent implements OnInit {
   gaugeValue: number = 50; // linear gauge value
   gaugePreviousValue: number = 70;
 
+  // heatmap
+  heatmapMin: number = 0;
+  heatmapMax: number = 50000;
+
   // Combo Chart
   barChart: any[] = barChart;
   lineChartSeries: any[] = lineChartSeries;

--- a/demo/chartTypes.ts
+++ b/demo/chartTypes.ts
@@ -250,7 +250,7 @@ const chartGroups = [
         options: [
           'animations', 'colorScheme', 'showXAxis', 'showYAxis', 'gradient', 'showLegend',
           'showXAxisLabel', 'xAxisLabel', 'showYAxisLabel', 'yAxisLabel',
-          'innerPadding', 'tooltipDisabled'
+          'innerPadding', 'tooltipDisabled', 'min', 'max'
         ],
         defaults: {
           yAxisLabel: 'Census Date',
@@ -275,7 +275,7 @@ const chartGroups = [
         inputFormat: 'singleSeries',
         options: [
           'showLegend', 'legendTitle', 'colorScheme', 'min', 'max', 'largeSegments', 'smallSegments', 'units',
-          'angleSpan', 'startAngle', 'showAxis', 'margin', 'tooltipDisabled', 'animations', 
+          'angleSpan', 'startAngle', 'showAxis', 'margin', 'tooltipDisabled', 'animations',
         ]
       },
       {
@@ -305,7 +305,7 @@ const chartGroups = [
         inputFormat: 'calendarData',
         options: [
           'animations', 'colorScheme', 'showXAxis', 'showYAxis', 'gradient', 'showLegend',
-          'innerPadding', 'tooltipDisabled'
+          'innerPadding', 'tooltipDisabled', 'min', 'max'
         ],
         defaults: {
           width: 1100,

--- a/src/heat-map/heat-map.component.ts
+++ b/src/heat-map/heat-map.component.ts
@@ -11,6 +11,7 @@ import { scaleBand } from 'd3-scale';
 import { BaseChartComponent } from '../common/base-chart.component';
 import { calculateViewDimensions, ViewDimensions } from '../common/view-dimensions.helper';
 import { ColorHelper } from '../common/color.helper';
+import { DeprecatedI18NPipesModule } from '@angular/common';
 
 @Component({
   selector: 'ngx-charts-heat-map',
@@ -83,6 +84,8 @@ export class HeatMapComponent extends BaseChartComponent {
   @Input() yAxisTickFormatting: any;
   @Input() tooltipDisabled: boolean = false;
   @Input() tooltipText: any;
+  @Input() min: any;
+  @Input() max: any;
 
   @ContentChild('tooltipTemplate') tooltipTemplate: TemplateRef<any>;
 
@@ -129,8 +132,14 @@ export class HeatMapComponent extends BaseChartComponent {
     });
 
     if (this.scaleType === 'linear') {
-      const min = Math.min(0, ...this.valueDomain);
-      const max = Math.max(...this.valueDomain);
+      let min = this.min;
+      let max = this.max;
+      if (!this.min) {
+        min = Math.min(0, ...this.valueDomain);
+      }
+      if (!this.max) {
+        max = Math.max(...this.valueDomain);
+      }
       this.valueDomain = [min, max];
     }
 
@@ -140,7 +149,7 @@ export class HeatMapComponent extends BaseChartComponent {
     this.setColors();
     this.legendOptions = this.getLegendOptions();
 
-    this.transform = `translate(${ this.dims.xOffset } , ${ this.margin[0] })`;
+    this.transform = `translate(${this.dims.xOffset} , ${this.margin[0]})`;
     this.rects = this.getRects();
   }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
this is a PR for https://github.com/swimlane/ngx-charts/issues/602
previously there was no way to set min and max values for heatmaps


**What is the new behavior?**
you can set the min as well as max for heatmap if not provided they will be calculated as before from the given data

**Does this PR introduce a breaking change?** (check one with "x")
- [ x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
