### PR TITLE
Round the individual bars up

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
@@ -156,9 +156,9 @@ export class SeriesVerticalComponent implements OnChanges {
         const offset1 = offset0 + value;
         d0[d0Type] += value;
 
-        bar.height = this.yScale(offset0) - this.yScale(offset1);
+        bar.height = Math.ceil(this.yScale(offset0) - this.yScale(offset1));
         bar.x = 0;
-        bar.y = this.yScale(offset1);
+        bar.y = Math.ceil(this.yScale(offset1));
         bar.offset0 = offset0;
         bar.offset1 = offset1;
       } else if (this.type === 'normalized') {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x ] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Small gaps appear between bars in stacked bar chart. The scale function works with
fractions. Since those fractions are used to set height and y for bars, we end
up with fractions of a pixel. It is then up to the browser to round it and
browsers do that differently. If bar #1 is rounded down and bar #2 is rounded up,
we get gaps.
Issue: https://github.com/swimlane/ngx-charts/issues/892

**What is the new behavior?**
To round all of the bar heights up, since the scale function works with fractions.

❗ Please consider if this is the way to go or if you rather want to move towards scale functions not working on fractions. If so then this PR should be scrapped.

Before
![image](https://user-images.githubusercontent.com/22211891/86316607-73c40d80-bc2d-11ea-86d8-c50f9aae45f5.png)

After
![image](https://user-images.githubusercontent.com/22211891/86316679-ab32ba00-bc2d-11ea-9100-7d839a14b277.png)

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x ] No

