### PR TITLE
feat: resize observer support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3246,6 +3246,12 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==",
       "dev": true
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.4.tgz",
+      "integrity": "sha512-rPvqs+1hL/5hbES/0HTdUu4lvNmneiwKwccbWe7HGLWbnsLdqKnQHyWLg4Pj0AMO7PLHCwBM1Cs8orChdkDONg==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/jasminewd2": "~2.0.3",
     "@types/json-schema": "^7.0.4",
     "@types/node": "^12.11.1",
+    "@types/resize-observer-browser": "^0.1.4",
     "angular-cli-ghpages": "^0.6.2",
     "codelyzer": "^6.0.0",
     "cross-env": "^7.0.2",

--- a/projects/swimlane/ngx-charts/src/lib/utils/resize-observer.service.ts
+++ b/projects/swimlane/ngx-charts/src/lib/utils/resize-observer.service.ts
@@ -1,0 +1,34 @@
+/// <reference types="resize-observer-browser" />
+
+import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ResizeObserverService {
+  private resizeEventSubject = new Subject<readonly ResizeObserverEntry[]>();
+  private resizeObserver: ResizeObserver | null;
+  public resizeEvent$ = this.resizeEventSubject.asObservable();
+
+  constructor() {
+    if (window.ResizeObserver) {
+      this.resizeObserver = new ResizeObserver(entries => {
+        this.resizeEventSubject.next(entries);
+      });
+    }
+  }
+
+  observe(element: HTMLElement): Observable<boolean> {
+    this.resizeObserver?.observe(element);
+    return this.resizeEventSubject.asObservable().pipe(
+      filter(entries => entries.some(entry => entry.target === element)),
+      map(() => true)
+    );
+  }
+
+  unobserve(element: HTMLElement) {
+    this.resizeObserver?.unobserve(element);
+  }
+}

--- a/projects/swimlane/ngx-charts/tsconfig.lib.json
+++ b/projects/swimlane/ngx-charts/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "target": "es2015",
     "declaration": true,
     "inlineSources": true,
-    "types": [],
+    "typeRoots": ["../../../node_modules/@types"],
     "lib": ["dom", "es2018"]
   },
   "angularCompilerOptions": {

--- a/projects/swimlane/ngx-charts/tsconfig.spec.json
+++ b/projects/swimlane/ngx-charts/tsconfig.spec.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "../../../out-tsc/spec",
+    "typeRoots": ["../../../node_modules/@types"],
     "types": ["jasmine", "node"]
   },
   "files": ["src/test.ts"],


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x ] Feature

**What is the current behavior?** (You can also link to an open issue here)
Component only updates/resizes on window resize


**What is the new behavior?**
Component only updates/resizes on window resize AND element resize


**Does this PR introduce a breaking change?** (check one with "x")
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
BaseChartComponent has a new dependency: 

```typescript
constructor(
    protected chartElement: ElementRef,
    protected zone: NgZone,
    protected cd: ChangeDetectorRef,
    protected resizeObserverService: ResizeObserverService
  ) {}
```

**Other information**:
Since 

* both events are merged and debounced 
* checks are made if ResizeObserver is defined

it works in older browsers too.