### PR TITLE
feat: add custom colors & ref lines to vert. stacked chart

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
@@ -62,6 +62,10 @@ import { ViewDimensions } from '../common/types/view-dimension.interface';
           [maxTickLength]="maxYAxisTickLength"
           [tickFormatting]="yAxisTickFormatting"
           [ticks]="yAxisTicks"
+          [referenceLines]="referenceLines"
+          [showRefLines]="showRefLines"
+          [showRefLabels]="showRefLabels"
+          [showRefIconPlaceholder]="showRefIconPlaceholder"
           (dimensionsChanged)="updateYAxisWidth($event)"
         ></svg:g>
         <svg:g
@@ -140,6 +144,10 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Input() showDataLabel: boolean = false;
   @Input() dataLabelFormatting: any;
   @Input() noBarWhenZero: boolean = true;
+  @Input() showRefLines: boolean = false;
+  @Input() referenceLines: any;
+  @Input() showRefLabels: boolean = true;
+  @Input() showRefIconPlaceholder: boolean = false;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
   @Output() deactivate: EventEmitter<any> = new EventEmitter();

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
@@ -187,13 +187,13 @@ export class SeriesVerticalComponent implements OnChanges {
       }
 
       if (this.colors.scaleType === ScaleType.Ordinal) {
-        bar.color = this.colors.getColor(label);
+        bar.color = this.colors.getColor(label, this.seriesName);
       } else {
         if (this.type === BarChartType.Standard) {
-          bar.color = this.colors.getColor(value);
+          bar.color = this.colors.getColor(value, this.seriesName);
           bar.gradientStops = this.colors.getLinearGradientStops(value);
         } else {
-          bar.color = this.colors.getColor(bar.offset1);
+          bar.color = this.colors.getColor(bar.offset1, this.seriesName);
           bar.gradientStops = this.colors.getLinearGradientStops(bar.offset1, bar.offset0);
         }
       }

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/axis-label.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/axis-label.component.ts
@@ -7,7 +7,7 @@ import { Orientation } from '../types/orientation.enum';
     <svg:text
       [attr.stroke-width]="strokeWidth"
       [attr.x]="x"
-      [attr.y]="y"
+      [attr.y]="showRefIconPlaceholder ? y - 10 : y"
       [attr.text-anchor]="textAnchor"
       [attr.transform]="transform"
     >
@@ -22,6 +22,7 @@ export class AxisLabelComponent implements OnChanges {
   @Input() offset: number;
   @Input() width: number;
   @Input() height: number;
+  @Input() showRefIconPlaceholder: boolean;
 
   x: number;
   y: number;

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
@@ -28,7 +28,7 @@ import { TextAnchor } from '../types/text-anchor.enum';
         <svg:text
           stroke-width="0.01"
           [attr.dy]="dy"
-          [attr.x]="x1"
+          [attr.x]="showRefLines && showRefIconPlaceholder ? x1 - 12 : x1"
           [attr.y]="y1"
           [attr.text-anchor]="textAnchor"
           [style.font-size]="'12px'"
@@ -65,10 +65,19 @@ import { TextAnchor } from '../types/text-anchor.enum';
       <svg:g *ngIf="showRefLines" [attr.transform]="transform(refLine.value)">
         <svg:line
           class="refline-path gridline-path-horizontal"
-          x1="0"
-          [attr.x2]="gridLineWidth"
+          x1="-10"
+          [attr.x2]="gridLineWidth + 10"
           [attr.transform]="gridLineTransform()"
         />
+        <svg:g *ngIf="showRefIconPlaceholder">
+          <svg:rect
+          id="{{ 'refIconPlaceholder' + refLine.name}}"
+          [attr.y]="-5"
+          [attr.x]="-12"
+          height="10"
+          width="10"
+          opacity="0"/>
+        </svg:g>
         <svg:g *ngIf="showRefLabels">
           <title>{{ tickTrim(tickFormat(refLine.value)) }}</title>
           <svg:text
@@ -101,6 +110,7 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
   @Input() referenceLines;
   @Input() showRefLabels: boolean = false;
   @Input() showRefLines: boolean = false;
+  @Input() showRefIconPlaceholder: boolean = false;
 
   @Output() dimensionsChanged = new EventEmitter();
 

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis.component.ts
@@ -32,6 +32,7 @@ import { ViewDimensions } from '../types/view-dimension.interface';
         [referenceLines]="referenceLines"
         [showRefLines]="showRefLines"
         [showRefLabels]="showRefLabels"
+        [showRefIconPlaceholder]="showRefIconPlaceholder"
         [height]="dims.height"
         (dimensionsChanged)="emitTicksWidth($event)"
       />
@@ -44,6 +45,7 @@ import { ViewDimensions } from '../types/view-dimension.interface';
         [orient]="yOrient"
         [height]="dims.height"
         [width]="dims.width"
+        [showRefIconPlaceholder]="showRefLines && showRefIconPlaceholder"
       ></svg:g>
     </svg:g>
   `,
@@ -64,6 +66,7 @@ export class YAxisComponent implements OnChanges {
   @Input() referenceLines;
   @Input() showRefLines: boolean;
   @Input() showRefLabels: boolean;
+  @Input() showRefIconPlaceholder: boolean;
   @Input() yAxisOffset: number = 0;
   @Output() dimensionsChanged = new EventEmitter();
 

--- a/projects/swimlane/ngx-charts/src/lib/common/color.helper.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/color.helper.ts
@@ -75,7 +75,7 @@ export class ColorHelper {
     return colorScale;
   }
 
-  getColor(value: StringOrNumberOrDate): string {
+  getColor(value: StringOrNumberOrDate, label?: StringOrNumberOrDate): string {
     if (value === undefined || value === null) {
       throw new Error('Value can not be null');
     }
@@ -93,9 +93,10 @@ export class ColorHelper {
       const formattedValue = value.toString();
       let found: any; // todo type customColors
       if (this.customColors && this.customColors.length > 0) {
-        found = this.customColors.find(mapping => {
-          return mapping.name.toLowerCase() === formattedValue.toLowerCase();
-        });
+        found = this.customColors.find((mapping: {name: string, label: string, value: string}) => 
+          (mapping.name.toLowerCase() === formattedValue.toLowerCase()) &&
+          (mapping.label ? (mapping.label === label) : true)
+        );
       }
 
       if (found) {

--- a/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/line-chart/line-chart.component.ts
@@ -75,6 +75,7 @@ import { ViewDimensions } from '../common/types/view-dimension.interface';
           [referenceLines]="referenceLines"
           [showRefLines]="showRefLines"
           [showRefLabels]="showRefLabels"
+          [showRefIconPlaceholder]="showRefIconPlaceholder"
           (dimensionsChanged)="updateYAxisWidth($event)"
         ></svg:g>
         <svg:g [attr.clip-path]="clipPath">
@@ -208,6 +209,7 @@ export class LineChartComponent extends BaseChartComponent {
   @Input() showRefLines: boolean = false;
   @Input() referenceLines: any;
   @Input() showRefLabels: boolean = true;
+  @Input() showRefIconPlaceholder: boolean = false;
   @Input() xScaleMin: number;
   @Input() xScaleMax: number;
   @Input() yScaleMin: number;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -152,6 +152,7 @@
         *ngIf="chartType === 'bar-vertical-stacked'"
         class="chart-container"
         [view]="view"
+        [customColors]="customColors"
         [scheme]="colorScheme"
         [schemeType]="schemeType"
         [results]="multi"
@@ -943,6 +944,7 @@
         [showRefLines]="showRefLines"
         [showRefLabels]="showRefLabels"
         [referenceLines]="refLines"
+        [showRefIconPlaceholder]="showRefIconPlaceholder"
         [trimXAxisTicks]="trimXAxisTicks"
         [trimYAxisTicks]="trimYAxisTicks"
         [maxXAxisTickLength]="maxXAxisTickLength"
@@ -952,6 +954,46 @@
         (deactivate)="deactivate($event)"
       >
       </ngx-charts-line-chart>
+      <ngx-charts-bar-vertical-stacked
+        *ngIf="chartType === 'bar-vertical-stacked-ref-lines'"
+        class="chart-container"
+        [view]="view"
+        [scheme]="colorScheme"
+        [schemeType]="schemeType"
+        [results]="multi"
+        [animations]="animations"
+        [gradient]="gradient"
+        [tooltipDisabled]="tooltipDisabled"
+        [xAxis]="showXAxis"
+        [yAxis]="showYAxis"
+        [legend]="showLegend"
+        [legendTitle]="legendTitle"
+        [legendPosition]="legendPosition"
+        (legendLabelClick)="onLegendLabelClick($event)"
+        [showXAxisLabel]="showXAxisLabel"
+        [showYAxisLabel]="showYAxisLabel"
+        [xAxisLabel]="xAxisLabel"
+        [yAxisLabel]="yAxisLabel"
+        [showGridLines]="showGridLines"
+        [barPadding]="barPadding"
+        [roundDomains]="roundDomains"
+        [yScaleMax]="yScaleMax"
+        [noBarWhenZero]="noBarWhenZero"
+        [showDataLabel]="showDataLabel"
+        [trimXAxisTicks]="trimXAxisTicks"
+        [trimYAxisTicks]="trimYAxisTicks"
+        [rotateXAxisTicks]="rotateXAxisTicks"
+        [maxXAxisTickLength]="maxXAxisTickLength"
+        [maxYAxisTickLength]="maxYAxisTickLength"
+        [referenceLines]="refLinesBar"
+        [showRefLines]="showRefLines"
+        [showRefLabels]="showRefLabels"
+        [showRefIconPlaceholder]="showRefIconPlaceholder"
+        (select)="select($event)"
+        (activate)="activate($event)"
+        (deactivate)="deactivate($event)"
+      >
+      </ngx-charts-bar-vertical-stacked>
       <ngx-charts-bar-vertical
         *ngIf="chartType === 'tooltip-templates'"
         class="chart-container"
@@ -1215,6 +1257,13 @@
           <label>
             <input type="checkbox" [(ngModel)]="showRefLabels" />
             Show Reference Labels
+          </label>
+          <br />
+        </div>
+        <div *ngIf="chart.options.includes('showRefIconPlaceholder')">
+          <label>
+            <input type="checkbox" [checked]="showRefIconPlaceholder" (change)="showRefIconPlaceholder = $event.target.checked" />
+            Enable Reference Label Placeholder
           </label>
           <br />
         </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -168,6 +168,15 @@ export class AppComponent implements OnInit {
     {
       name: 'Germany',
       value: '#a8385d'
+    },
+    {
+      name: '2010',
+      label: 'United Kingdom',
+      value: 'rgba(200,150,50)'
+    },
+    {
+      name: '2010',
+      value: 'rgb(200,200,200)'
     }
   ];
 
@@ -247,6 +256,8 @@ export class AppComponent implements OnInit {
   // Reference lines
   showRefLines: boolean = true;
   showRefLabels: boolean = true;
+  showRefIconPlaceholder: boolean = true;
+  refLinesBar = [{name: 'Threshold', value: 95000}];
 
   // Supports any number of reference lines.
   refLines = [

--- a/src/app/chartTypes.ts
+++ b/src/app/chartTypes.ts
@@ -173,7 +173,11 @@ const chartGroups = [
           'trimYAxisTicks',
           'rotateXAxisTicks',
           'maxXAxisTickLength',
-          'maxYAxisTickLength'
+          'maxYAxisTickLength', 
+          'showRefLines',
+          'referenceLines', 
+          'showRefLabels',
+          'showRefIconPlaceholder'
         ]
       },
       {
@@ -838,6 +842,7 @@ const chartGroups = [
           'showRefLines',
           'referenceLines',
           'showRefLabels',
+          'showRefIconPlaceholder',
           'trimXAxisTicks',
           'trimYAxisTicks',
           'maxXAxisTickLength',
@@ -848,6 +853,42 @@ const chartGroups = [
           xAxisLabel: 'Year',
           linearScale: false
         }
+      },
+      {
+        name: 'Stacked Vertical Bar Chart with Reference Lines',
+        selector: 'bar-vertical-stacked-ref-lines',
+        inputFormat: 'multiSeries',
+        options: [
+          'animations',
+          'colorScheme',
+          'schemeType',
+          'showXAxis',
+          'showYAxis',
+          'gradient',
+          'barPadding',
+          'noBarWhenZero',
+          'showLegend',
+          'legendTitle',
+          'legendPosition',
+          'showXAxisLabel',
+          'xAxisLabel',
+          'showYAxisLabel',
+          'yAxisLabel',
+          'showGridLines',
+          'roundDomains',
+          'tooltipDisabled',
+          'yScaleMax',
+          'showDataLabel',
+          'trimXAxisTicks',
+          'trimYAxisTicks',
+          'rotateXAxisTicks',
+          'maxXAxisTickLength',
+          'maxYAxisTickLength', 
+          'showRefLines',
+          'referenceLines', 
+          'showRefLabels',
+          'showRefIconPlaceholder'
+        ]
       },
       {
         name: 'Timeline Filter Bar Chart',


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the new behavior?**

- Added reference lines to the stacked vertical bar chart component. Use these attributes:
```
[referenceLines]="refLinesBar"
[showRefLines]="showRefLines"
[showRefLabels]="showRefLabels"
```
- Added reference line icon placeholder. Which can be used to place icons next to the reference line. Added on stacked vertical bar chart and line chart component:
```
[showRefIconPlaceholder]="showRefIconPlaceholder"
```
- The id of the placholder is: `{{ 'refIconPlaceholder' + refLine.name}}`

- custom colors can now be specified for a single label (inside a series) and not only for the whole series:
  ```JavaScript
  customColors = [
    {
      name: '2010',
      label: 'United Kingdom',    // <-- was not possible before
      value: 'rgba(200,150,50)'
    },
    {
      name: '2010',
      value: 'rgb(200,200,200)'
    }
  ];
  ```
- hint: you have to specify the 'labeled' colors first if you want to override a more generic rule which would also fit.


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No


