### PR TITLE
fix(tooltip-area): refactor tooltip styles for CSP nonce compliance

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/tooltip-area.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/tooltip-area.component.ts
@@ -39,7 +39,8 @@ export interface Tooltip {
         y="0"
         [attr.width]="dims.width"
         [attr.height]="dims.height"
-        style="opacity: 0; cursor: 'auto';"
+        [style.opacity]="0"
+        [style.cursor]="'auto'"
         (mousemove)="mouseMove($event)"
         (mouseleave)="hideTooltip()"
       />


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
The tooltip in the area chart relies on inline style bindings ([style.opacity], [style.cursor]) that cause issues in environments enforcing strict Content Security Policy (CSP).

**What is the new behavior?**
What is the new behavior?
The tooltip has been refactored to use CSS classes and Angular bindings that properly support enforcement. This fix ensures correct rendering of the tooltip both in CSP-restricted environments with nonce and in environments without CSP.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ X ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Tested in browsers with strict CSP headers requiring nonce and without CSP; tooltip functions correctly in both scenarios without style or security violations.