### PR TITLE
feat: Added utility method to round off percentages in Advanced Pie Chart.

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.spec.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.spec.ts
@@ -145,7 +145,7 @@ describe('<ngx-charts-advanced-legend>', () => {
     ]);
   });
 
-  it('should round percentages to sum to 100% when roundPercentages is true', () => {
+  it('should round percentages with 2 decimals and sum to 100% when roundPercentages is true', () => {
     TestBed.overrideComponent(TestComponent, {
       set: {
         template: `
@@ -169,17 +169,17 @@ describe('<ngx-charts-advanced-legend>', () => {
     const { legendItemPercentElements } = loadLegendItemElements(fixture);
 
     expect(Array.from(legendItemPercentElements).map((x: Element) => x.textContent.trim())).toEqual([
-      '6%',
-      '9%',
-      '14%',
-      '21%',
-      '33%',
-      '17%'
+      '5.71%',
+      '8.57%',
+      '14.29%',
+      '21.43%',
+      '32.86%',
+      '17.14%'
     ]);
 
     const percentages = Array.from(legendItemPercentElements).map((x: Element) => {
       const text = x.textContent.trim();
-      return parseInt(text.replace('%', ''));
+      return parseFloat(text.replace('%', ''));
     });
 
     const sum = percentages.reduce((a, b) => a + b, 0);

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.spec.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.spec.ts
@@ -56,6 +56,7 @@ describe('<ngx-charts-advanced-legend>', () => {
                   [data]="data"
                   [width]="legendWidth"
                   [animations]="false"
+                  [roundPercentages]="false"
                   [valueFormatting]="valueFormatting"
                   [labelFormatting]="labelFormatting"
                   [percentageFormatting]="percentageFormatting">
@@ -142,6 +143,47 @@ describe('<ngx-charts-advanced-legend>', () => {
       '33%',
       '17%'
     ]);
+  });
+
+  it('should round percentages to sum to 100% when roundPercentages is true', () => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `
+          <ngx-charts-advanced-legend
+            [label]="legendLabel"
+            [colors]="colors"
+            [data]="data"
+            [width]="legendWidth"
+            [animations]="false"
+            [roundPercentages]="true"
+            [valueFormatting]="valueFormatting"
+            [labelFormatting]="labelFormatting"
+            [percentageFormatting]="percentageFormatting">
+          </ngx-charts-advanced-legend>
+        `
+      }
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    const { legendItemPercentElements } = loadLegendItemElements(fixture);
+
+    expect(Array.from(legendItemPercentElements).map((x: Element) => x.textContent.trim())).toEqual([
+      '6%',
+      '9%',
+      '14%',
+      '21%',
+      '33%',
+      '17%'
+    ]);
+
+    const percentages = Array.from(legendItemPercentElements).map((x: Element) => {
+      const text = x.textContent.trim();
+      return parseInt(text.replace('%', ''));
+    });
+
+    const sum = percentages.reduce((a, b) => a + b, 0);
+    expect(sum).toBe(100);
   });
 
   function loadLegendItemElements(fixture: ComponentFixture<TestComponent>) {

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.spec.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.spec.ts
@@ -186,6 +186,126 @@ describe('<ngx-charts-advanced-legend>', () => {
     expect(sum).toBe(100);
   });
 
+  it('should ensure rounded percentages sum to 100% for equal percentage values', () => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `
+          <ngx-charts-advanced-legend
+            [label]="legendLabel"
+            [colors]="colors"
+            [data]="data"
+            [width]="legendWidth"
+            [animations]="false"
+            [roundPercentages]="true"
+            [valueFormatting]="valueFormatting"
+            [labelFormatting]="labelFormatting"
+            [percentageFormatting]="percentageFormatting">
+          </ngx-charts-advanced-legend>
+        `
+      }
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const component = fixture.componentInstance;
+
+    // Three equal values(33.33% each)
+    component.data = [
+      { name: 'a', value: 1 },
+      { name: 'b', value: 1 },
+      { name: 'c', value: 1 }
+    ];
+    fixture.detectChanges();
+    const { legendItemPercentElements } = loadLegendItemElements(fixture);
+    const percentages = Array.from(legendItemPercentElements).map((x: Element) => {
+      const text = x.textContent.trim();
+      return parseFloat(text.replace('%', ''));
+    });
+    const sum = Number(percentages.reduce((a, b) => a + b, 0).toFixed(2));
+    expect(sum).toBe(100);
+  });
+
+  it('should ensure rounded percentages sum to 100% for edge cases', () => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `
+          <ngx-charts-advanced-legend
+            [label]="legendLabel"
+            [colors]="colors"
+            [data]="data"
+            [width]="legendWidth"
+            [animations]="false"
+            [roundPercentages]="true"
+            [valueFormatting]="valueFormatting"
+            [labelFormatting]="labelFormatting"
+            [percentageFormatting]="percentageFormatting">
+          </ngx-charts-advanced-legend>
+        `
+      }
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const component = fixture.componentInstance;
+
+    // Mixed values with one dominant value
+    component.data = [
+      { name: 'a', value: 900 },
+      { name: 'b', value: 1 },
+      { name: 'c', value: 2 },
+      { name: 'd', value: 3 },
+      { name: 'e', value: 4 },
+      { name: 'f', value: 5 }
+    ];
+    fixture.detectChanges();
+    const { legendItemPercentElements } = loadLegendItemElements(fixture);
+    const percentages = Array.from(legendItemPercentElements).map((x: Element) => {
+      const text = x.textContent.trim();
+      return parseFloat(text.replace('%', ''));
+    });
+    const sum = Number(percentages.reduce((a, b) => a + b, 0).toFixed(2));
+    expect(sum).toBe(100);
+  });
+
+  it('should ensure rounded percentages sum to 0 if all values are zero', () => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `
+          <ngx-charts-advanced-legend
+            [label]="legendLabel"
+            [colors]="colors"
+            [data]="data"
+            [width]="legendWidth"
+            [animations]="false"
+            [roundPercentages]="true"
+            [valueFormatting]="valueFormatting"
+            [labelFormatting]="labelFormatting"
+            [percentageFormatting]="percentageFormatting">
+          </ngx-charts-advanced-legend>
+        `
+      }
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(TestComponent);
+    const component = fixture.componentInstance;
+
+    // All zero values
+    component.data = [
+      { name: 'a', value: 0 },
+      { name: 'b', value: 0 },
+      { name: 'c', value: 0 },
+      { name: 'd', value: 0 },
+      { name: 'e', value: 0 },
+      { name: 'f', value: 0 }
+    ];
+    fixture.detectChanges();
+    const { legendItemPercentElements } = loadLegendItemElements(fixture);
+    const percentages = Array.from(legendItemPercentElements).map((x: Element) => {
+      const text = x.textContent.trim();
+      return parseFloat(text.replace('%', ''));
+    });
+    const sum = Number(percentages.reduce((a, b) => a + b, 0).toFixed(2));
+    expect(sum).toBe(0);
+  });
+
   function loadLegendItemElements(fixture: ComponentFixture<TestComponent>) {
     const legendItemsElements = fixture.debugElement.nativeElement.querySelector('.legend-items');
     const legendItemValueElements = fixture.debugElement.nativeElement.querySelectorAll('.legend-items .item-value');

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.ts
@@ -12,7 +12,7 @@ import { trimLabel } from '../trim-label.helper';
 import { formatLabel } from '../label.helper';
 import { DataItem, StringOrNumberOrDate } from '../../models/chart-data.model';
 import { ColorHelper } from '../color.helper';
-import { roundPercentages } from '../percentage.helper';
+import { roundPercentagesWithDecimals } from '../percentage.helper';
 
 export interface AdvancedLegendItem {
   value: StringOrNumberOrDate;
@@ -68,6 +68,7 @@ export interface AdvancedLegendItem {
               *ngIf="animations"
               class="item-percent"
               ngx-charts-count-up
+              [countDecimals]="2"
               [countTo]="legendItem.percentage"
               [countSuffix]="'%'"
             ></div>
@@ -121,7 +122,9 @@ export class AdvancedLegendComponent implements OnChanges {
 
   getLegendItems(): AdvancedLegendItem[] {
     const values = this.data.map(d => Number(d.value));
-    const percentages = this.roundPercentages ? roundPercentages(values) : values.map(v => (v / this.total) * 100);
+    const percentages = this.roundPercentages
+      ? roundPercentagesWithDecimals(values)
+      : values.map(v => (v / this.total) * 100);
 
     return (this.data as any).map((d, index) => {
       const label = formatLabel(d.name);
@@ -138,7 +141,9 @@ export class AdvancedLegendComponent implements OnChanges {
         label: formattedLabel,
         displayLabel: trimLabel(formattedLabel, 20),
         origialLabel: d.name,
-        percentage: this.percentageFormatting ? this.percentageFormatting(percentage) : percentage.toLocaleString()
+        percentage: this.percentageFormatting
+          ? this.percentageFormatting(parseFloat(percentage.toLocaleString()))
+          : percentage.toLocaleString()
       };
     });
   }

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/advanced-legend.component.ts
@@ -12,6 +12,7 @@ import { trimLabel } from '../trim-label.helper';
 import { formatLabel } from '../label.helper';
 import { DataItem, StringOrNumberOrDate } from '../../models/chart-data.model';
 import { ColorHelper } from '../color.helper';
+import { roundPercentages } from '../percentage.helper';
 
 export interface AdvancedLegendItem {
   value: StringOrNumberOrDate;
@@ -87,6 +88,7 @@ export class AdvancedLegendComponent implements OnChanges {
   @Input() colors: ColorHelper;
   @Input() label: string = 'Total';
   @Input() animations: boolean = true;
+  @Input() roundPercentages: boolean = true;
 
   @Output() select: EventEmitter<DataItem> = new EventEmitter();
   @Output() activate: EventEmitter<DataItem> = new EventEmitter();
@@ -118,11 +120,14 @@ export class AdvancedLegendComponent implements OnChanges {
   }
 
   getLegendItems(): AdvancedLegendItem[] {
-    return (this.data as any).map(d => {
+    const values = this.data.map(d => Number(d.value));
+    const percentages = this.roundPercentages ? roundPercentages(values) : values.map(v => (v / this.total) * 100);
+
+    return (this.data as any).map((d, index) => {
       const label = formatLabel(d.name);
       const value = d.value;
       const color = this.colors.getColor(label);
-      const percentage = this.total > 0 ? (value / this.total) * 100 : 0;
+      const percentage = this.roundPercentages ? percentages[index] : this.getPercentage(values[index]);
       const formattedLabel = typeof this.labelFormatting === 'function' ? this.labelFormatting(label) : label;
 
       return {
@@ -136,6 +141,10 @@ export class AdvancedLegendComponent implements OnChanges {
         percentage: this.percentageFormatting ? this.percentageFormatting(percentage) : percentage.toLocaleString()
       };
     });
+  }
+
+  getPercentage(value: number): number {
+    return this.total > 0 ? (value / this.total) * 100 : 0;
   }
 
   trackBy(index: number, item: AdvancedLegendItem) {

--- a/projects/swimlane/ngx-charts/src/lib/common/percentage.helper.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/percentage.helper.ts
@@ -15,8 +15,8 @@ export function roundPercentages(values: number[]): number[] {
   const raw = values.map(v => (v / totalValue) * 100);
   const floored = raw.map(v => Math.floor(v));
   const remainders = raw.map((v, i) => ({ i, remainder: v - floored[i] }));
-  let sum = floored.reduce((a, b) => a + b, 0);
-  let diff = 100 - sum;
+  const sum = floored.reduce((a, b) => a + b, 0);
+  const diff = 100 - sum;
 
   if (diff > 0) {
     // Adding points to values with large remainder

--- a/projects/swimlane/ngx-charts/src/lib/common/percentage.helper.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/percentage.helper.ts
@@ -1,0 +1,47 @@
+/**
+ * Rounds percentages using the largest remainder method to ensure they always sum to 100%
+ *
+ * @param values Array of numeric values
+ * @returns Array of rounded percentages
+ */
+export function roundPercentages(values: number[]): number[] {
+  const totalValue = values.reduce((a, b) => a + b, 0);
+
+  if (totalValue === 0) {
+    // It total is 0 return all values as 0
+    return Array(values.length).fill(0);
+  }
+
+  const raw = values.map(v => (v / totalValue) * 100);
+  const floored = raw.map(v => Math.floor(v));
+  const remainders = raw.map((v, i) => ({ i, remainder: v - floored[i] }));
+  let sum = floored.reduce((a, b) => a + b, 0);
+  let diff = 100 - sum;
+
+  if (diff > 0) {
+    // Adding points to values with large remainder
+    remainders
+      .sort((a, b) => b.remainder - a.remainder)
+      .slice(0, diff)
+      .forEach(r => floored[r.i]++);
+  } else if (diff < 0) {
+    // Removing points from values with small remainder
+    remainders
+      .sort((a, b) => a.remainder - b.remainder)
+      .slice(0, -diff)
+      .forEach(r => floored[r.i]--);
+  }
+
+  return floored;
+}
+
+/**
+ * Calculates and formats percentages
+ *
+ * @param values Array of numeric values
+ * @returns Array of formatted percentage strings
+ */
+export function calculateAccuratePercentages(values: number[]): string[] {
+  const roundedPercentages = roundPercentages(values);
+  return roundedPercentages.map(p => p.toString());
+}

--- a/projects/swimlane/ngx-charts/src/lib/common/percentage.helper.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/percentage.helper.ts
@@ -2,46 +2,28 @@
  * Rounds percentages using the largest remainder method to ensure they always sum to 100%
  *
  * @param values Array of numeric values
- * @returns Array of rounded percentages
+ * @returns Array of rounded percentages with decimals
  */
-export function roundPercentages(values: number[]): number[] {
-  const totalValue = values.reduce((a, b) => a + b, 0);
+export function roundPercentagesWithDecimals(values: number[], decimals: number = 2): string[] {
+  const total = values.reduce((a, b) => a + b, 0);
+  if (total === 0) return values.map(_ => '0.00');
+  const scale = Math.pow(10, decimals + 2);
+  const rawUnits = values.map(v => (v / total) * scale);
+  const floored = rawUnits.map(u => Math.floor(u));
+  const remainders = rawUnits.map((u, i) => ({ i, rem: u - floored[i] }));
 
-  if (totalValue === 0) {
-    // It total is 0 return all values as 0
-    return Array(values.length).fill(0);
-  }
-
-  const raw = values.map(v => (v / totalValue) * 100);
-  const floored = raw.map(v => Math.floor(v));
-  const remainders = raw.map((v, i) => ({ i, remainder: v - floored[i] }));
-  const sum = floored.reduce((a, b) => a + b, 0);
-  const diff = 100 - sum;
-
+  const sumFloored = floored.reduce((a, b) => a + b, 0);
+  const diff = scale - sumFloored;
   if (diff > 0) {
-    // Adding points to values with large remainder
-    remainders
-      .sort((a, b) => b.remainder - a.remainder)
-      .slice(0, diff)
-      .forEach(r => floored[r.i]++);
+    remainders.sort((a, b) => b.rem - a.rem);
+    for (let k = 0; k < diff; k++) {
+      floored[remainders[k].i] += 1;
+    }
   } else if (diff < 0) {
-    // Removing points from values with small remainder
-    remainders
-      .sort((a, b) => a.remainder - b.remainder)
-      .slice(0, -diff)
-      .forEach(r => floored[r.i]--);
+    remainders.sort((a, b) => a.rem - b.rem);
+    for (let k = 0; k < -diff; k++) {
+      floored[remainders[k].i] -= 1;
+    }
   }
-
-  return floored;
-}
-
-/**
- * Calculates and formats percentages
- *
- * @param values Array of numeric values
- * @returns Array of formatted percentage strings
- */
-export function calculateAccuratePercentages(values: number[]): string[] {
-  const roundedPercentages = roundPercentages(values);
-  return roundedPercentages.map(p => p.toString());
+  return floored.map(u => (u / 100).toFixed(2));
 }


### PR DESCRIPTION
Introduces a percentage.helper.ts utility that implements the 'largest remainder method' to ensure legend percentages sum to 100%. Updated AdvancedLegendComponent to use this helper and added an input 'roundPercentages' to toggle rounded percentages.

**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently the percentages in the advanced pie chart component are not always summing to give 100%.


**What is the new behavior?**
With the updated code changes the percentages are rounded off using the largest remiander method and this ensures percentages sums to 100%


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce percentage rounding helper and toggle in AdvancedLegend to display 2-decimal percentages that sum to 100%, with tests updated/added.
> 
> - **AdvancedLegendComponent (`advanced-legend.component.ts`)**:
>   - Add input `roundPercentages` (default `true`) to toggle rounded percentages.
>   - Compute percentages via `roundPercentagesWithDecimals` when enabled; fallback to raw `(value/total)*100` via `getPercentage`.
>   - Pass `[countDecimals]="2"` to animated percent display; adjust percentage formatting flow.
> - **Utility (`percentage.helper.ts`)**:
>   - New `roundPercentagesWithDecimals(values, decimals=2)` using largest remainder method to ensure percentages sum to 100%.
> - **Tests (`advanced-legend.component.spec.ts`)**:
>   - Default template sets `[roundPercentages]="false"` for existing expectations.
>   - Add test asserting 2-decimal rounded percentages and total sum equals 100 when `roundPercentages` is `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74e1e928b8d22924e087ad64ea58bf37decb7f34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->