### PR TITLE
Area Chart SSR 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix: Area Charts were not server-side renderable
+
 ## 24.0.0-alpha.0
 
 - Enhancement: Added support for Angular 21

--- a/projects/swimlane/ngx-charts/src/lib/common/area.component.spec.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/area.component.spec.ts
@@ -1,0 +1,36 @@
+import { ElementRef } from '@angular/core';
+
+import { AreaComponent } from './area.component';
+
+describe('AreaComponent SSR paths', () => {
+  const finalPath = 'M0,200L100,50L200,100L300,25L300,200L0,200Z';
+  const startingPath = 'M0,200L100,200L200,200L300,200L300,200L0,200Z';
+
+  function createComponent(animations: boolean): AreaComponent {
+    const component = new AreaComponent({
+      nativeElement: document.createElementNS('http://www.w3.org/2000/svg', 'g')
+    } as ElementRef);
+    component.path = finalPath;
+    component.startingPath = startingPath;
+    component.animations = animations;
+    return component;
+  }
+
+  it('uses final path when animations are disabled', () => {
+    const component = createComponent(false);
+
+    component.ngOnChanges();
+
+    expect(component.areaPath).toBe(finalPath);
+    expect(component.areaPath).not.toBe(startingPath);
+  });
+
+  it('starts from baseline when animations are enabled', () => {
+    const component = createComponent(true);
+    vi.spyOn(component, 'updatePathEl').mockImplementation(() => {});
+
+    component.ngOnChanges();
+
+    expect(component.areaPath).toBe(startingPath);
+  });
+});

--- a/projects/swimlane/ngx-charts/src/lib/common/area.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/area.component.ts
@@ -52,7 +52,7 @@ export class AreaComponent implements OnChanges {
   ngOnChanges(): void {
     this.update();
 
-    if (!this.animationsLoaded) {
+    if (this.animations && !this.animationsLoaded) {
       this.loadAnimation();
       this.animationsLoaded = true;
     }
@@ -69,10 +69,18 @@ export class AreaComponent implements OnChanges {
       this.hasGradient = false;
     }
 
+    if (!this.animations && this.path) {
+      this.areaPath = this.path;
+    }
+
     this.updatePathEl();
   }
 
   loadAnimation(): void {
+    if (!this.animations) {
+      return;
+    }
+
     this.areaPath = this.startingPath;
     setTimeout(this.updatePathEl.bind(this), 100);
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Area Charts are not server-side renderable due to the lack of animations being suppressed.


**What is the new behavior?**

- fix: server-side rendering works in area charts

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to area fill animation logic with targeted tests; no API or auth changes.
> 
> **Overview**
> Fixes **area chart SSR** by honoring the `animations` flag in `AreaComponent` instead of always running the first-load animation path.
> 
> When **animations are off** (typical for SSR), `areaPath` is set directly to the final `path` in `update()`, and `loadAnimation()` no longer runs (including no `setTimeout`). When **animations stay on**, behavior is unchanged: first paint uses `startingPath`, then transitions to `path`. New unit tests cover both paths; changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12decc7d3ff6844af1324f97e01723842ab2c90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->