### PR TITLE
(release): 24.0.0-alpha.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To learn how to use the ngx-charts components to build custom charts and find ex
 - Run `git checkout -b release/X.Y.Z`
 - Update version in `projects/swimlane/ngx-charts/package.json`
 - Update changelog in `projects/docs/changelog.md`
+- Run `yarn package`
 - Run `git commit -am "(release): X.Y.Z"`
 - Run `git tag X.Y.Z`
 - Run `git push origin HEAD --tags`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 24.0.0-alpha.1
+
 - Fix: Area Charts were not server-side renderable
 
 ## 24.0.0-alpha.0

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-charts",
-  "version": "24.0.0-alpha.0",
+  "version": "24.0.0-alpha.1",
   "description": "Declarative Charting Framework for Angular",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

- Fix: Area Charts were not server-side renderable

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release housekeeping (version, changelog, docs); no runtime code changes in this diff.
> 
> **Overview**
> **Release `24.0.0-alpha.1`** bumps `@swimlane/ngx-charts` from `24.0.0-alpha.0` to **`24.0.0-alpha.1`** and documents the shipped fix: **area charts were not server-side renderable**.
> 
> The **README** release checklist now includes running **`yarn package`** before the release commit (between changelog updates and `git commit`).
> 
> This PR is **metadata and process only**—no library source changes in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 836327e7ac73490ab9853478d4e9229f9e67cb38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->