### PR TITLE
Upgrade to Angular 21 and apply Okendo fork customizations

### DIFF
--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@swimlane/ngx-charts",
-  "version": "24.0.0-alpha.1",
+  "name": "@okendo/ngx-charts",
+  "version": "21.0.0",
   "description": "Declarative Charting Framework for Angular",
   "repository": {
     "type": "git",

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-vertical-stacked.component.ts
@@ -49,6 +49,7 @@ import { ViewDimensions } from '../common/types/view-dimension.interface';
           [tickFormatting]="xAxisTickFormatting"
           [ticks]="xAxisTicks"
           [xAxisOffset]="dataLabelMaxHeight.negative"
+          [chartLeftOffset]="chartLeftOffset"
           [wrapTicks]="wrapTicks"
           (dimensionsChanged)="updateXAxisHeight($event)"
         ></svg:g>
@@ -88,7 +89,9 @@ import { ViewDimensions } from '../common/types/view-dimension.interface';
               [showDataLabel]="showDataLabel"
               [dataLabelFormatting]="dataLabelFormatting"
               [seriesName]="group.name"
+              [roundEdges]="roundEdges"
               [animations]="animations"
+              [chartLeftOffset]="chartLeftOffset"
               [noBarWhenZero]="noBarWhenZero"
               (select)="onClick($event, group)"
               (activate)="onActivate($event, group)"
@@ -117,7 +120,9 @@ import { ViewDimensions } from '../common/types/view-dimension.interface';
               [showDataLabel]="showDataLabel"
               [dataLabelFormatting]="dataLabelFormatting"
               [seriesName]="group.name"
+              [roundEdges]="roundEdges"
               [animations]="animations"
+              [chartLeftOffset]="chartLeftOffset"
               [noBarWhenZero]="noBarWhenZero"
               (select)="onClick($event, group)"
               (activate)="onActivate($event, group)"
@@ -170,11 +175,14 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   @Input() xAxisTicks: any[];
   @Input() yAxisTicks: any[];
   @Input() barPadding: number = 8;
+  @Input() roundEdges: boolean = true;
   @Input() roundDomains: boolean = false;
+  @Input() yScaleMin: number;
   @Input() yScaleMax: number;
   @Input() showDataLabel: boolean = false;
   @Input() dataLabelFormatting: any;
   @Input() noBarWhenZero: boolean = true;
+  @Input() barMaxWidth: number = 100;
   @Input() wrapTicks = false;
 
   @Output() activate: EventEmitter<any> = new EventEmitter();
@@ -197,6 +205,7 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
   legendOptions: LegendOptions;
   dataLabelMaxHeight: any = { negative: 0, positive: 0 };
   isSSR = false;
+  chartLeftOffset: number = 0;
 
   barChartType = BarChartType;
 
@@ -245,6 +254,15 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
 
     this.xScale = this.getXScale();
     this.yScale = this.getYScale();
+
+    if (this.results.length > 0) {
+      const firstGroupName = this.results[0].name;
+      const lastGroupName = this.results[this.results.length - 1].name;
+      const chartWidth =
+        this.xScale(lastGroupName) - this.xScale(firstGroupName) + this.xScale.bandwidth();
+
+      this.chartLeftOffset = (this.dims.width - chartWidth) / 2 - this.xScale(firstGroupName);
+    }
 
     this.setColors();
     this.legendOptions = this.getLegendOptions();
@@ -296,14 +314,19 @@ export class BarVerticalStackedComponent extends BaseChartComponent {
     domain.push(smallest);
     domain.push(biggest);
 
-    const min = Math.min(0, ...domain);
+    const min = this.yScaleMin ? Math.min(this.yScaleMin, ...domain) : Math.min(0, ...domain);
     const max = this.yScaleMax ? Math.max(this.yScaleMax, ...domain) : Math.max(...domain);
     return [min, max];
   }
 
   getXScale(): any {
     const spacing = this.groupDomain.length / (this.dims.width / this.barPadding + 1);
-    return scaleBand().rangeRound([0, this.dims.width]).paddingInner(spacing).domain(this.groupDomain);
+    const maxWidth = Math.min(this.barMaxWidth * this.groupDomain.length, this.dims.width);
+
+    return scaleBand()
+      .rangeRound([0, this.barMaxWidth ? maxWidth : this.dims.width])
+      .paddingInner(spacing)
+      .domain(this.groupDomain);
   }
 
   getYScale(): any {

--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/series-vertical.component.ts
@@ -133,6 +133,7 @@ export class SeriesVerticalComponent implements OnChanges {
   @Input() showDataLabel: boolean = false;
   @Input() dataLabelFormatting: any;
   @Input() noBarWhenZero: boolean = true;
+  @Input() chartLeftOffset: number = 0;
 
   @Output() select: EventEmitter<DataItem> = new EventEmitter();
   @Output() activate = new EventEmitter();
@@ -181,12 +182,27 @@ export class SeriesVerticalComponent implements OnChanges {
       total = this.series.map(d => d.value).reduce((sum, d) => sum + d, 0);
     }
 
+    let topNameOfGroup: string | undefined;
+
+    for (let i = this.series.length - 1; i >= 0; i--) {
+      if (this.series[i].value !== 0) {
+        topNameOfGroup = this.series[i].name as string;
+        break;
+      }
+    }
+
     this.bars = this.series.map((d, index) => {
       let value = d.value as any;
       const label = this.getLabel(d);
       const formattedLabel = formatLabel(label);
-      const roundEdges = this.roundEdges;
       d0Type = value > 0 ? D0Types.positive : D0Types.negative;
+      let roundEdges;
+
+      if (this.type === BarChartType.Stacked && (d.name !== topNameOfGroup || d0Type === D0Types.negative)) {
+        roundEdges = false;
+      } else {
+        roundEdges = this.roundEdges;
+      }
 
       const bar: any = {
         value,
@@ -215,7 +231,7 @@ export class SeriesVerticalComponent implements OnChanges {
         d0[d0Type] += value;
 
         bar.height = this.yScale(offset0) - this.yScale(offset1);
-        bar.x = 0;
+        bar.x = this.chartLeftOffset;
         bar.y = this.yScale(offset1);
         bar.offset0 = offset0;
         bar.offset1 = offset1;

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/x-axis.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/x-axis.component.ts
@@ -69,6 +69,7 @@ export class XAxisComponent implements OnChanges {
   @Input() showRefLines: boolean;
   @Input() showRefLabels: boolean;
   @Input() xAxisOffset: number = 0;
+  @Input() chartLeftOffset: number = 0;
   @Input() wrapTicks = false;
 
   @Output() dimensionsChanged = new EventEmitter();
@@ -93,7 +94,7 @@ export class XAxisComponent implements OnChanges {
   }
 
   update(): void {
-    this.transform = `translate(0,${this.xAxisOffset + this.padding + this.dims.height})`;
+    this.transform = `translate(${this.chartLeftOffset},${this.xAxisOffset + this.padding + this.dims.height})`;
 
     if (typeof this.xAxisTickCount !== 'undefined') {
       this.tickArguments = [this.xAxisTickCount];


### PR DESCRIPTION
- Reset to upstream swimlane/ngx-charts master (Angular 21, v24.0.0-alpha.1)
- Apply Okendo-specific changes:
  - bar-vertical-stacked: add roundEdges, yScaleMin, barMaxWidth inputs
  - bar-vertical-stacked: compute chartLeftOffset to center chart in container
  - series-vertical: fix roundEdges logic (only round top positive bar in stacked mode)
  - series-vertical: use chartLeftOffset for stacked bar x-position
  - x-axis: add chartLeftOffset input to shift axis with centered bars
  - package.json: rename to @okendo/ngx-charts v21.0.0
