### PR TITLE
fix: y axis labels for ssr

### DIFF
--- a/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/bar-chart/bar-horizontal.component.ts
@@ -17,6 +17,8 @@ import { LegendOptions, LegendPosition } from '../common/types/legend.model';
 import { ScaleType } from '../common/types/scale-type.enum';
 import { ViewDimensions } from '../common/types/view-dimension.interface';
 import { select } from 'd3-selection';
+import { formatLabel } from '../common/label.helper';
+import { YAxisTicksComponent } from '../common/axes/y-axis-ticks.component';
 
 @Component({
   selector: 'ngx-charts-bar-horizontal',
@@ -163,6 +165,9 @@ export class BarHorizontalComponent extends BaseChartComponent {
 
     this.margin = [10, 20 + this.dataLabelMaxWidth.positive, 10, 20 + this.dataLabelMaxWidth.negative];
 
+    // Seed axis width before first measure so SSR/print HTML reserves label space.
+    this.seedYAxisWidthFromResults();
+
     this.dims = calculateViewDimensions({
       width: this.width,
       height: this.height,
@@ -193,6 +198,19 @@ export class BarHorizontalComponent extends BaseChartComponent {
       const refLines = select(this.chartElement.nativeElement).selectAll('.ref-line').nodes() as HTMLElement[];
       refLines.forEach(line => parent.appendChild(line));
     }
+  }
+
+  /** Approx Y-axis width from category labels when not yet measured (SSR-safe). */
+  seedYAxisWidthFromResults(): void {
+    if (!this.yAxis || this.yAxisWidth > 0 || !this.results?.length) {
+      return;
+    }
+    const labels = this.results.map(d => formatLabel(d.name ?? d.label));
+    this.yAxisWidth = YAxisTicksComponent.approximateTickLabelsWidth(
+      labels,
+      this.trimYAxisTicks !== false,
+      this.maxYAxisTickLength ?? 16
+    );
   }
 
   getXScale(): any {
@@ -258,11 +276,17 @@ export class BarHorizontalComponent extends BaseChartComponent {
   }
 
   updateYAxisWidth({ width }: { width: number }): void {
+    if (width === this.yAxisWidth) {
+      return;
+    }
     this.yAxisWidth = width;
     this.update();
   }
 
   updateXAxisHeight({ height }: { height: number }): void {
+    if (height === this.xAxisHeight) {
+      return;
+    }
     this.xAxisHeight = height;
     this.update();
   }

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis-ticks.component.ts
@@ -150,14 +150,20 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    setTimeout(() => this.updateDims());
+    // Browser: measure after paint. SSR width is applied synchronously in update().
+    if (isPlatformBrowser(this.platformId)) {
+      setTimeout(() => this.updateDims());
+    }
   }
 
   updateDims(): void {
     if (!isPlatformBrowser(this.platformId)) {
-      // for SSR, use approximate value instead of measured
-      this.width = this.getApproximateAxisWidth();
-      this.dimensionsChanged.emit({ width: this.width });
+      // SSR: approximate — no DOM metrics available
+      const width = this.getApproximateAxisWidth();
+      if (width > 0 && width !== this.width) {
+        this.width = width;
+        this.dimensionsChanged.emit({ width: this.width });
+      }
       return;
     }
 
@@ -255,7 +261,13 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
         break;
       default:
     }
-    setTimeout(() => this.updateDims());
+
+    // SSR must reserve axis width before HTML serialize (no deferred setTimeout).
+    if (!isPlatformBrowser(this.platformId)) {
+      this.updateDims();
+    } else {
+      setTimeout(() => this.updateDims());
+    }
   }
 
   setReferencelines(): void {
@@ -314,10 +326,26 @@ export class YAxisTicksComponent implements OnChanges, AfterViewInit {
     return this.trimTicks ? trimLabel(label, this.maxTickLength) : label;
   }
 
+  /** Approx px width for SSR / pre-measure seeding. */
+  static readonly APPROX_CHAR_WIDTH = 7;
+
+  static approximateTickLabelsWidth(labels: string[], trimTicks: boolean = true, maxTickLength: number = 16): number {
+    if (!labels?.length) {
+      return 0;
+    }
+    const maxChars = Math.max(
+      0,
+      ...labels.map(label => (trimTicks ? trimLabel(label, maxTickLength) : String(label)).length)
+    );
+    return maxChars * YAxisTicksComponent.APPROX_CHAR_WIDTH;
+  }
+
   getApproximateAxisWidth(): number {
-    const maxChars = Math.max(...this.ticks.map(t => this.tickTrim(this.tickFormat(t)).length));
-    const charWidth = 7;
-    return maxChars * charWidth;
+    if (!this.ticks?.length || !this.tickFormat) {
+      return 0;
+    }
+    const labels = this.ticks.map(t => this.tickTrim(this.tickFormat(t)));
+    return YAxisTicksComponent.approximateTickLabelsWidth(labels, false, this.maxTickLength);
   }
 
   tickChunks(label: string): string[] {

--- a/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/axes/y-axis.component.ts
@@ -80,6 +80,8 @@ export class YAxisComponent implements OnChanges {
   tickStroke: string = '#CCC';
   strokeWidth: number = 1;
   padding: number = 5;
+  /** Last tick-label width emitted to the parent chart (not conflated with labelOffset). */
+  private emittedTickWidth: number | null = null;
 
   @ViewChild(YAxisTicksComponent) ticksComponent: YAxisTicksComponent;
 
@@ -102,16 +104,16 @@ export class YAxisComponent implements OnChanges {
   }
 
   emitTicksWidth({ width }): void {
-    if (width !== this.labelOffset && this.yOrient === Orientation.Right) {
-      this.labelOffset = width + this.labelOffset;
-      setTimeout(() => {
-        this.dimensionsChanged.emit({ width });
-      }, 0);
-    } else if (width !== this.labelOffset) {
-      this.labelOffset = width;
-      setTimeout(() => {
-        this.dimensionsChanged.emit({ width });
-      }, 0);
+    if (width == null || width === this.emittedTickWidth) {
+      return;
     }
+    this.emittedTickWidth = width;
+    if (this.yOrient === Orientation.Right) {
+      this.labelOffset = width + 65;
+    } else {
+      this.labelOffset = width;
+    }
+    // Sync emit so SSR HTML serializes with reserved y-axis width (no setTimeout).
+    this.dimensionsChanged.emit({ width });
   }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Y Axis labels can appear cut off during server-side rendering.

<img width="1035" height="628" alt="Screenshot 2026-07-30 at 11 28 53 AM" src="https://github.com/user-attachments/assets/efa0a455-41dd-45c0-b92e-1ec448740129" />


**What is the new behavior?**

Y-axis labels are not cut off, appear truncated when label exceeds available width.

<img width="880" height="734" alt="Screenshot 2026-07-30 at 11 22 58 AM" src="https://github.com/user-attachments/assets/19d7f725-d7b7-4e53-b1dd-a5658d5490bc" />


**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chart axis sizing and SSR/browser measurement timing; no API or data-handling changes, with minor risk of approximate width differing slightly from browser-measured width until hydration.
> 
> **Overview**
> Fixes **Y-axis category labels clipping** on server-rendered horizontal bar charts by reserving tick-label width **before** layout runs, instead of relying on post-paint DOM measurement (which SSR never gets).
> 
> **`YAxisTicksComponent`** adds shared **`approximateTickLabelsWidth`** (7px per character, trim-aware) and runs **`updateDims()` synchronously on SSR** during `update()` so width is known when HTML is serialized. **`YAxisComponent.emitTicksWidth`** no longer compares tick width to **`labelOffset`** or defers emits with `setTimeout`; it tracks the last emitted width and emits **`dimensionsChanged` synchronously**.
> 
> **`BarHorizontalComponent`** seeds **`yAxisWidth`** from result labels via that helper when width is still zero, and skips redundant **`update()`** when axis width/height events repeat the same value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f782b5364dd31d70e4b9d61ea6db401bda6cf31c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->