### PR TITLE
fix: truncation in legend

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+- Fix: Side legend labels now truncate with CSS ellipsis instead of being hard-clipped when the legend width is constrained
+
 ## 24.0.1
 
 - Fix: Y-axis labels were cut off, misaligned when server-side rendered.

--- a/projects/swimlane/ngx-charts/src/lib/common/charts/chart.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/charts/chart.component.ts
@@ -22,6 +22,8 @@ import { ScaleType } from '../types/scale-type.enum';
       <ngx-charts-scale-legend
         *ngIf="showLegend && legendType === LegendType.ScaleLegend"
         class="chart-legend"
+        [style.width.px]="legendWidth"
+        [style.maxWidth.px]="legendWidth"
         [horizontal]="legendOptions && legendOptions.position === LegendPosition.Below"
         [valueRange]="legendOptions.domain"
         [colors]="legendOptions.colors"
@@ -32,6 +34,8 @@ import { ScaleType } from '../types/scale-type.enum';
       <ngx-charts-legend
         *ngIf="showLegend && legendType === LegendType.Legend"
         class="chart-legend"
+        [style.width.px]="legendWidth"
+        [style.maxWidth.px]="legendWidth"
         [horizontal]="legendOptions && legendOptions.position === LegendPosition.Below"
         [data]="legendOptions.domain"
         [title]="legendOptions.title"

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend-entry.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend-entry.component.ts
@@ -3,7 +3,13 @@ import { Component, Input, Output, ChangeDetectionStrategy, HostListener, EventE
 @Component({
   selector: 'ngx-charts-legend-entry',
   template: `
-    <span [title]="formattedLabel" tabindex="-1" [class.active]="isActive" (click)="select.emit(formattedLabel)">
+    <span
+      [title]="formattedLabel"
+      tabindex="-1"
+      class="legend-entry"
+      [class.active]="isActive"
+      (click)="select.emit(formattedLabel)"
+    >
       <span class="legend-label-color" [style.background-color]="color" (click)="toggle.emit(formattedLabel)"> </span>
       <span class="legend-label-text">
         {{ trimmedLabel }}

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.scss
@@ -1,7 +1,10 @@
 .chart-legend {
   display: inline-block;
   padding: 0;
-  width: auto !important;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow: hidden;
+  vertical-align: top;
 
   .legend-title {
     white-space: nowrap;
@@ -19,27 +22,49 @@
     list-style: none;
   }
 
-  .horizontal-legend {
-    li {
-      display: inline-block;
+  .vertical-legend {
+    .legend-label {
+      width: 100%;
+      max-width: calc(100% - 20px);
+    }
+
+    .legend-entry {
+      display: flex;
+      flex-grow: 1;
+      align-items: center;
+      overflow: hidden;
     }
   }
 
   .legend-wrap {
     width: calc(100% - 10px);
+    min-width: 0;
   }
 
   .legend-labels {
     line-height: 85%;
     list-style: none;
     text-align: left;
-    float: left;
-    width: 100%;
-    border-radius: 3px;
-    overflow-y: auto;
-    overflow-x: hidden;
+    display: flex;
+    flex-wrap: wrap;
     white-space: nowrap;
+    border-radius: 3px;
     background: rgba(0, 0, 0, 0.05);
+
+    &.vertical-legend {
+      overflow-x: hidden;
+      overflow-y: auto;
+    }
+
+    &.horizontal-legend {
+      max-width: 100%;
+      overflow-x: auto;
+      overflow-y: hidden;
+
+      li {
+        display: inline-block;
+      }
+    }
   }
 
   .legend-label {
@@ -66,6 +91,7 @@
     display: inline-block;
     height: 15px;
     width: 15px;
+    min-width: 15px;
     margin-right: 5px;
     color: #5b646b;
     border-radius: 3px;
@@ -76,7 +102,6 @@
     vertical-align: top;
     line-height: 15px;
     font-size: 12px;
-    width: calc(100% - 20px);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.spec.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.spec.ts
@@ -7,11 +7,19 @@ import { Color } from '../../utils/color-sets';
 import { ScaleType } from '../types/scale-type.enum';
 
 const seriesData = ['complete', 'not complete'];
+const longLabel = 'A very long legend label that should truncate with an ellipsis when the legend width is constrained';
 
 @Component({
   selector: 'test-component',
   template: `
-    <ngx-charts-legend [title]="legendTitle" [colors]="colors" [data]="seriesData" [height]="legendHeight">
+    <ngx-charts-legend
+      class="chart-legend"
+      [title]="legendTitle"
+      [colors]="colors"
+      [data]="seriesData"
+      [height]="legendHeight"
+      [width]="legendWidth"
+    >
     </ngx-charts-legend>
   `,
   imports: [ChartCommonModule]
@@ -20,7 +28,8 @@ class TestComponent {
   seriesData: any = seriesData;
   legendTitle: string = 'Test legend title';
   colors: any;
-  legendHeight: number;
+  legendHeight: number = 200;
+  legendWidth: number = 120;
 
   constructor() {
     const scheme: Color = {
@@ -51,5 +60,39 @@ describe('<ngx-charts-legend>', () => {
 
     expect(labelsElement.children[0].textContent).toContain('complete');
     expect(labelsElement.children[1].textContent).toContain('not complete');
+  });
+
+  it('should apply vertical-legend class when horizontal is false', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const labelsElement = fixture.debugElement.nativeElement.querySelector('.legend-labels');
+
+    expect(labelsElement.classList.contains('vertical-legend')).toBe(true);
+    expect(labelsElement.classList.contains('horizontal-legend')).toBe(false);
+  });
+
+  it('should render legend-entry nodes for CSS ellipsis layout', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const entries = fixture.debugElement.nativeElement.querySelectorAll('.legend-entry');
+
+    expect(entries.length).toEqual(2);
+  });
+
+  it('should keep full label in title and use ellipsis styles for long labels', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.componentInstance.seriesData = [longLabel];
+    fixture.detectChanges();
+
+    const entry = fixture.debugElement.nativeElement.querySelector('.legend-entry');
+    const text = fixture.debugElement.nativeElement.querySelector('.legend-label-text');
+    const styles = getComputedStyle(text);
+
+    expect(entry.getAttribute('title')).toBe(longLabel);
+    expect(styles.textOverflow).toBe('ellipsis');
+    expect(styles.overflow).toBe('hidden');
+    expect(styles.whiteSpace).toBe('nowrap');
   });
 });

--- a/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.ts
+++ b/projects/swimlane/ngx-charts/src/lib/common/legend/legend.component.ts
@@ -26,7 +26,13 @@ export interface LegendEntry {
         <span class="legend-title-text">{{ title }}</span>
       </header>
       <div class="legend-wrap">
-        <ul class="legend-labels" [class.horizontal-legend]="horizontal" [style.max-height.px]="height - 45">
+        <ul
+          class="legend-labels"
+          [class.horizontal-legend]="horizontal"
+          [class.vertical-legend]="!horizontal"
+          [style.max-height.px]="!horizontal ? height - 45 : null"
+          [style.max-width.px]="horizontal && width ? width - 10 : null"
+        >
           <li *ngFor="let entry of legendEntries; trackBy: trackBy" class="legend-label">
             <ngx-charts-legend-entry
               [label]="entry.label"


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Legend labels appear cut off for charts.

**What is the new behavior?**

Legend labels that exceed the width of the container truncate properly with ellipsis.

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only legend/CSS and layout changes with added unit tests; no API or data-handling changes.
> 
> **Overview**
> **Fixes side legend labels** that were hard-clipped when the legend column was narrow. Labels now show **CSS ellipsis** while the full text stays on the entry `title` for hover.
> 
> The chart wrapper binds **explicit width and max-width** from `legendWidth` on both legend types so the legend cannot grow past its allocated column. Legend layout moves from float-based rules to **flex** with separate **vertical** vs **horizontal** overflow (vertical scroll, horizontal scroll when below the chart). Legend entries get a `legend-entry` wrapper class so flex + `overflow: hidden` lets `text-overflow: ellipsis` on `.legend-label-text` actually apply.
> 
> Tests cover vertical-legend class, entry DOM, and computed ellipsis styles for long labels under a constrained width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c730cebecdf7315fddde16ecde9ca54b4e06930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->