### PR TITLE
(release): 25.0.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## HEAD (unreleased)
 
+## 25.0.0
+
 - Enhancement: Added support for Angular 22
 - Breaking: Dropped support for Angular 19 and 20 (requires Angular 21.2+)
 

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-charts",
-  "version": "24.0.2",
+  "version": "25.0.0",
   "description": "Declarative Charting Framework for Angular",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump `@swimlane/ngx-charts` to **25.0.0**
- Document Angular 22 support and dropping Angular 19/20 (requires Angular 21.2+)

## Test plan
- [ ] Confirm changelog and package version are correct
- [ ] CI passes on this branch
- [ ] After merge, publish separately with `yarn publish:lib` when ready


Made with [Cursor](https://cursor.com)