### PR TITLE
(release): 25.0.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,8 +4,7 @@
 
 ## 25.0.1
 
-- Fix: Side legend labels now truncate with CSS ellipsis instead of being hard-clipped when the legend width is constrained (ported from 24.0.2)
-- Fix: Y-axis labels were cut off / misaligned when server-side rendered (ported from 24.0.1)
+- Chore: Sync 25.x release with master (includes maintenance fixes already present on git that were missing from the original npm 25.0.0 publish)
 
 ## 25.0.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 ## HEAD (unreleased)
 
+## 25.0.1
+
+- Fix: Side legend labels now truncate with CSS ellipsis instead of being hard-clipped when the legend width is constrained (ported from 24.0.2)
+- Fix: Y-axis labels were cut off / misaligned when server-side rendered (ported from 24.0.1)
+
 ## 25.0.0
 
 - Enhancement: Added support for Angular 22

--- a/projects/swimlane/ngx-charts/package.json
+++ b/projects/swimlane/ngx-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swimlane/ngx-charts",
-  "version": "25.0.0",
+  "version": "25.0.1",
   "description": "Declarative Charting Framework for Angular",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Patch release to sync npm 25.x with current master

**What is the current behavior?** (You can also link to an open issue here)

npm `@swimlane/ngx-charts@25.0.0` was published before later master fixes landed. Git master already contains those changes; npm versions are immutable, so consumers still need a new publish.

**What is the new behavior?**

- Bumps library version to **25.0.1**
- Changelog notes this as a chore sync with master (no new code beyond release metadata)

After merge, publish with:

```bash
yarn publish:lib
```

**Does this PR introduce a breaking change?** (check one with "x")
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

### Test plan
- [ ] Confirm changelog + `projects/swimlane/ngx-charts/package.json` version are `25.0.1`
- [ ] CI passes
- [ ] After merge: `yarn publish:lib` and verify `npm view @swimlane/ngx-charts@25.0.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; no functional or API changes in the diff.
> 
> **Overview**
> **Patch release** so npm can ship what is already on `master`: `@swimlane/ngx-charts@25.0.0` was published before later maintenance fixes landed, and npm tags cannot be rewritten.
> 
> The diff only updates release metadata: `projects/swimlane/ngx-charts/package.json` goes from **25.0.0** to **25.0.1**, and `docs/changelog.md` adds a **25.0.1** section describing this chore sync. No library source changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 086a9b0025b3a78d75c4ff9b0635ccd91c0be2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->